### PR TITLE
Reorder the editable variables in common.yaml

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,9 +1,23 @@
 ---
 # Hosts & IPs
 # CHANGEME
-# Edit the following line to set a test user password:
+# Edit the following lines to set a test user password
+# and rabbitmq password
 deployments::profile::users::password: "test"
-# Edit the following subnet to match your network:
+rabbit_password: &rabbit_password "elmer_fudd"
+# Edit the following lines to replace "db_pass" with
+# something more secure for access each component has to
+# the database
+neutron::db::mysql::password: "db_pass"
+glance::db::mysql::password: "db_pass"
+keystone::db::mysql::password: "db_pass"
+cinder::db::mysql::password: "db_pass"
+ceilometer::db::mysql::password: "db_pass"
+ironic::db::mysql::password: "db_pass"
+nova::db::mysql::password: "db_pass"
+neutron::db::mysql::password: "db_pass"
+# Edit the following subnet to match the network your
+# OpenStack deployment will use.
 neutron_subnet:
   Subnet1:
     gateway_ip: 10.190.0.1
@@ -15,6 +29,7 @@ neutron_subnet:
     dns_nameservers:
      - 8.8.8.8
      - 8.8.4.4
+
 control_node: &control_node '127.0.0.1'
 
 # Version of CirrOS to install
@@ -85,31 +100,24 @@ neutron::agents::metadata::shared_secret: &shared_secret "something_secret"
 # Database stuff
 glance::registry::database_connection: &glance_db_connection "mysql://%{hiera('glance::db::mysql::user')}:%{hiera('glance::db::mysql::password')}@%{hiera('control_node')}/glance"
 glance::api::database_connection: *glance_db_connection
-glance::db::mysql::password: "db_pass"
 glance::db::mysql::user: "glance"
 glance::db::mysql::allowed_hosts: *control_node
 keystone::database_connection: "mysql://%{hiera('keystone::db::mysql::user')}:%{hiera('keystone::db::mysql::password')}@%{hiera('control_node')}/keystone"
-keystone::db::mysql::password: "db_pass"
 keystone::db::mysql::user: "keystone"
 keystone::db::mysql::allowed_hosts: *control_node
 cinder::database_connection: "mysql://%{hiera('cinder::db::mysql::user')}:%{hiera('cinder::db::mysql::password')}@%{hiera('control_node')}/cinder"
-cinder::db::mysql::password: "db_pass"
 cinder::db::mysql::user: "cinder"
 cinder::db::mysql::allowed_hosts: *control_node
 ceilometer::db::database_connection: "mysql://%{hiera('ceilometer::db::mysql::user')}:%{hiera('ceilometer::db::mysql::password')}@%{hiera('control_node')}/ceilometer"
-ceilometer::db::mysql::password: "db_pass"
 ceilometer::db::mysql::user: "ceilometer"
 ceilometer::db::mysql::allowed_hosts: *control_node
 ironic::db::database_connection: "mysql://%{hiera('ironic::db::mysql::user')}:%{hiera('ironic::db::mysql::password')}@%{hiera('control_node')}/ironic"
-ironic::db::mysql::password: "db_pass"
 ironic::db::mysql::user: "ironic"
 ironic::db::mysql::allowed_hosts: *control_node
 nova::db::database_connection: "mysql://%{hiera('nova::db::mysql::user')}:%{hiera('nova::db::mysql::password')}@%{hiera('control_node')}/nova"
-nova::db::mysql::password: "db_pass"
 nova::db::mysql::user: "nova"
 nova::db::mysql::allowed_hosts: *control_node
 neutron::server::database_connection: "mysql://%{hiera('neutron::db::mysql::user')}:%{hiera('neutron::db::mysql::password')}@%{hiera('control_node')}/neutron"
-neutron::db::mysql::password: "db_pass"
 neutron::db::mysql::user: "neutron"
 neutron::db::mysql::allowed_hosts: *control_node
 
@@ -252,7 +260,6 @@ nova::network::neutron::neutron_url: "http://%{hiera('control_node')}:9696"
 
 # Rabbit
 rabbitmq::server::node_ip_address: '0.0.0.0'
-rabbit_password: &rabbit_password "elmer_fudd"
 rabbit_host: &rabbit_host "%{hiera('control_node')}"
 rabbit_user: &rabbit_user "rabbit_user"
 rabbitmq::server::port: 5672

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,6 +1,20 @@
 ---
 # Hosts & IPs
 # CHANGEME
+# Edit the following line to set a test user password:
+deployments::profile::users::password: "test"
+# Edit the following subnet to match your network:
+neutron_subnet:
+  Subnet1:
+    gateway_ip: 10.190.0.1
+    network_name: Network1
+    cidr: 10.190.0.0/24
+    allocation_pools:
+      - start=10.190.0.5,end=10.190.0.254
+    enable_dhcp: false
+    dns_nameservers:
+     - 8.8.8.8
+     - 8.8.4.4
 control_node: &control_node '127.0.0.1'
 
 # Version of CirrOS to install
@@ -303,17 +317,6 @@ neutron_network:
     router_external: true
     provider_network_type: 'vxlan'
     ensure: present
-neutron_subnet:
-  Subnet1:
-    gateway_ip: 10.190.0.1
-    network_name: Network1
-    cidr: 10.190.0.0/24
-    allocation_pools:
-      - start=10.190.0.5,end=10.190.0.254
-    enable_dhcp: false
-    dns_nameservers:
-     - 8.8.8.8
-     - 8.8.4.4
 neutron::server::notifications::os_region_name: *region_name
 
 # Ceilometer
@@ -381,7 +384,6 @@ ironic::enable_drivers:
 # test user & openrc stuff
 deployments::profile::users::project: "test_project"
 deployments::profile::users::username: "test"
-deployments::profile::users::password: "test"
 deployments::profile::users::roles:
  - '_member_'
  - 'SwiftOperator'


### PR DESCRIPTION
We want the variables that should be edited by the user to be at the top of the file so they can easily find and edit them.
