### PR TITLE
Enable VNC on the compute node

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -4,6 +4,10 @@
 # This is the node where the API services, mysql, and RabbitMQ run.
 control_node: &control_node '127.0.0.1'
 
+# Edit the following line to set the IP address of your Compute node.
+# This is the node where VMs run.
+compute_node: &compute_node '127.0.0.1'
+
 # Edit the following line to set a test user password
 deployments::profile::users::password: "test"
 
@@ -247,6 +251,7 @@ nova::api::resume_guests_state_on_host_boot: true
 nova::api::service_neutron_metadata_proxy: true
 nova::vncproxy::host: *control_node
 nova::compute::vncproxy_host: *control_node
+nova::compute::vncserver_proxyclient_address: *compute_node
 nova::api::enabled: true
 nova::cert::enabled: true
 nova::compute::enabled: true


### PR DESCRIPTION
The VNC proxyclient is the IP of the compute node, so we need a way to
set it.
