### PR TITLE
Allow an override.yaml to take precedence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ puppetdb.conf
 Gemfile.lock
 Puppetfile.lock
 .tmp/
+override.yaml

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -7,4 +7,5 @@
 
 :hierarchy:
   - "node/%{::fqdn}"
+  - override
   - common


### PR DESCRIPTION
This allows for an override.yaml that would take precedence. It is
intentionally also in .gitignore since it's supposed to be never
checked in.
