### PR TITLE
Remove DHCP and nameservers from ext-net

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -54,10 +54,6 @@ neutron_subnet:
     cidr: 203.0.113.0/24
     allocation_pools:
       - start=203.0.113.5,end=203.0.113.200
-    enable_dhcp: true
-    dns_nameservers:
-     - 8.8.8.8
-     - 8.8.4.4
 
 # Version of CirrOS to install
 deployments::profile::glance::cirros_version: "0.3.4"


### PR DESCRIPTION
We really don't want a DHCP server running on our ext-net.
Confirmed Neutron gives out IPs from the allocation pool
just fine without it. We also don't need it to set the
nameservers.
