### PR TITLE
Tell nova to use keystonev3 to auth a token

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -289,7 +289,7 @@ nova::glance_api_servers: *glance_url
 nova::network::neutron::neutron_region_name: "%{hiera('region_name')}"
 nova::network::neutron::neutron_admin_password: *service_user_pass
 # This below will not work without a version on the endpoint.
-nova::network::neutron::neutron_admin_auth_url: "%{hiera('keystone::admin_endpoint')}/v2.0"
+nova::network::neutron::neutron_admin_auth_url: "%{hiera('keystone::admin_endpoint')}/v3"
 nova::network::neutron::neutron_url: "http://%{hiera('control_node')}:9696"
 
 # Nova ceiloemeter conenctions


### PR DESCRIPTION
This avoids the issues in nova-compute.log during instance creation where it shows something like:
2016-04-11 03:46:29.332 9913 ERROR nova.compute.manager ... NotFound: The resource could not be found. (HTTP 404)
