### PR TITLE
Remove redundant apt package installs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y puppet puppet-common ruby facter
+sudo apt-get install -y puppet
 sudo gem install --no-rdoc r10k
 
 sudo cp -a * /etc/puppet


### PR DESCRIPTION
In her review, crinkle pointed out that puppet-common, ruby and facter are already dependencies of the puppet package. No need to include them again (this script is also presented inline in the book, so simpler is better).
