### PR TITLE
No IPs by default

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -4,13 +4,13 @@
 # can be manually defined here:
 this_node: &this_node "%{::ipaddress}"
 
-# Edit the following line to set the IP address of your Control node.
-# This is the node where the API services, mysql, and RabbitMQ run.
-control_node: &control_node '127.0.0.1'
+# Uncomment & edit the following line to set the IP address of your Control
+# node. This is the node where the API services, mysql, and RabbitMQ run.
+#control_node: &control_node '127.0.0.1'
 
-# Edit the following line to set the IP address of your Compute node.
-# This is the node where VMs run.
-compute_node: &compute_node '127.0.0.1'
+# Uncomment & edit the following line to set the IP address of your 
+# Compute node. This is the node where VMs run.
+#compute_node: &compute_node '127.0.0.1'
 
 # Edit the following line to set a test user password
 deployments::profile::users::password: "test"


### PR DESCRIPTION
This will force users to enter correct IP addresses so that 127.0.0.1 is
not accidentally used.
